### PR TITLE
UX Improvements / Allow fix for deleting single node

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,11 @@
 # Obsidian Canvas MindMap
 
-- Press `Enter` to create brother card;
+- Press `Cmd` + `Enter` to create brother card;
 - Press `Tab` to create child card;
+- Press `Space` or `Enter` to start editing the selected node;
+    - When editing a node, press `Cmd` + `Enter` to exit editing (similar to `Escape`)
+	- This allows for fast chaining of nodes
 - Delete card to rearrange layout automatically;
-- Press `Alt` + `←/→/↓/↑` to navigate between cards;
 - Press `Cmd / Ctrl` + `←/→/↓/↑` to create floating cards;
 
 ## Showcase

--- a/src/mindMapSettings.ts
+++ b/src/mindMapSettings.ts
@@ -93,12 +93,29 @@ export class MindMapSettingTab extends PluginSettingTab {
 
 		this.useNavigateHotkeySetting(containerEl, this.plugin.settings);
 		this.createHotkeySetting(containerEl, this.plugin.settings);
+		this.autoLayoutSettings(containerEl, this.plugin.settings);
 
 		new Setting(containerEl)
 			.setName('Donate')
 			.setDesc('If you like this plugin, consider donating to support continued development:')
 			.addButton((bt) => {
 				bt.buttonEl.outerHTML = `<a href="https://www.buymeacoffee.com/boninall"><img src="https://img.buymeacoffee.com/button-api/?text=Buy me a coffee&emoji=&slug=boninall&button_colour=6495ED&font_colour=ffffff&font_family=Inter&outline_colour=000000&coffee_colour=FFDD00"></a>`;
+			});
+	}
+
+	autoLayoutSettings(containerEl: HTMLElement, setting: MindMapSettings) {
+		new Setting(containerEl)
+			.setName('Delete Node to Auto Layout')
+			.setDesc('Deleting MindMap nodes triggers automatic layout update')
+			.addToggle((toggle) => {
+				toggle.setValue(setting.layout.autoLayout);
+				toggle.onChange((value) => {
+					this.updateSettings('layout.autoLayout', value);
+
+					setTimeout(() => {
+						this.display();
+					}, 700);
+				});
 			});
 	}
 


### PR DESCRIPTION
Love the plugin @Quorafind, certainly an awesome way to improve the usage of Canvas.

I've made some improvements to my own local copy of the plugin, and thought they'd benefit other users.

Notable changes:
- Enter now enters edit mode (space still does also)
- Meta + Enter exits edit mode (both similar to excalidraw)
- Meta + Enter now allows for fast chaining of brother node (Enter to edit node, cmd+enter to exit edit, cmd+enter again to create another brother node)
- Add setting for delete auto layout (this might be considered a bug, this function prevents deletion of a single node)

Keen to hear your thoughts on these UX improvements and if there's anything you'd do differently and/or like me to change.

[This issue](https://github.com/Quorafind/Obsidian-Canvas-MindMap/issues/48) will be fixed with this PR.

Fixes https://github.com/Quorafind/Obsidian-Canvas-MindMap/issues/51 and https://github.com/Quorafind/Obsidian-Canvas-MindMap/issues/48